### PR TITLE
add whois server for pro zone

### DIFF
--- a/include/providers.hrl
+++ b/include/providers.hrl
@@ -1,5 +1,6 @@
 -define(PRVIDERS, [
   {"whois.tcinet.ru", <<"^.*com.ru$">>},
+  {"whois.registrypro.pro", <<"^.*pro$">>},
   {"whois.nic.ru", <<"^(.*)+\\.(org|net|com|msk|spb|nov|sochi).ru$">>},
   {"whois.nic.fm", <<"^(.*)+fm$">>},
   {"mn.whois-servers.net", <<"^(.*)+mn$">>},


### PR DESCRIPTION
Basic by  http://www.afilias.info  information

> Please refer below information to check whois information on pro zone domains 
> whois.afilias.net 
